### PR TITLE
Define game rules struct

### DIFF
--- a/truncate_core/src/board.rs
+++ b/truncate_core/src/board.rs
@@ -343,6 +343,25 @@ impl Board {
         }
     }
 
+    pub fn collect_combanants(
+        &self,
+        player: usize,
+        position: Coordinate,
+    ) -> (Vec<Vec<Coordinate>>, Vec<Vec<Coordinate>>) {
+        let attackers = self.get_words(position);
+        // Any neighbouring square belonging to another player is attacked. The words containing those squares are the defenders.
+        let defenders = self
+            .neighbouring_squares(position)
+            .iter()
+            .filter(|(_, square)| match square {
+                Square::Occupied(adjacent_player, _) => player != *adjacent_player,
+                _ => false,
+            })
+            .flat_map(|(position, _)| self.get_words(*position))
+            .collect();
+        (attackers, defenders)
+    }
+
     pub fn word_strings(
         &self,
         coordinates: &Vec<Vec<Coordinate>>,

--- a/truncate_core/src/game.rs
+++ b/truncate_core/src/game.rs
@@ -1,6 +1,7 @@
 use time::{Duration, OffsetDateTime};
 
 use crate::bag::TileBag;
+use crate::rules::GameRules;
 
 use super::board::Board;
 use super::judge::Judge;
@@ -10,6 +11,7 @@ use super::reporting::Change;
 
 #[derive(Default)]
 pub struct Game {
+    pub rules: GameRules,
     pub players: Vec<Player>,
     pub board: Board, // TODO: should these actually be public?
     pub bag: TileBag,
@@ -23,6 +25,7 @@ pub struct Game {
 impl Game {
     pub fn new(width: usize, height: usize) -> Self {
         Self {
+            rules: GameRules::default(),
             players: Vec::with_capacity(2),
             board: Board::new(width, height),
             bag: TileBag::default(),

--- a/truncate_core/src/lib.rs
+++ b/truncate_core/src/lib.rs
@@ -7,3 +7,4 @@ pub mod messages;
 pub mod moves;
 pub mod player;
 pub mod reporting;
+pub mod rules;

--- a/truncate_core/src/rules.rs
+++ b/truncate_core/src/rules.rs
@@ -1,0 +1,87 @@
+// TODO: Maximum consecutive swaps / stalemate rule
+
+pub enum WinCondition {
+    Destination,
+    Elimination,
+}
+
+pub enum Visibility {
+    Standard,
+    FogOfWar,
+}
+
+pub enum Truncation {
+    Root,
+    Larger,
+    None,
+}
+
+pub enum OvertimeRule {
+    FreeWildcard { period: usize },
+    RemoveTiles { period: usize, phase_time: usize },
+    Elimination,
+}
+
+pub enum Timing {
+    PerPlayer {
+        time_allowance: usize,
+        overtime_rule: OvertimeRule,
+    },
+    PerTurn {
+        time_allowance: usize,
+    },
+    Periodic {
+        turn_delay: usize,
+    },
+    None,
+}
+
+pub enum TileDistribution {
+    Standard,
+}
+
+pub enum TileBagBehaviour {
+    Standard,
+    Infinite,
+}
+
+pub struct BattleRules {
+    pub length_delta: isize,
+}
+
+pub enum Swapping {
+    Contiguous,
+    Universal,
+    None,
+}
+
+pub struct GameRules {
+    pub win_condition: WinCondition,
+    pub visibility: Visibility,
+    pub truncation: Truncation,
+    pub timing: Timing,
+    pub hand_size: usize,
+    pub tile_distribution: TileDistribution,
+    pub tile_bag_behaviour: TileBagBehaviour,
+    pub battle_rules: BattleRules,
+    pub swapping: Swapping,
+}
+
+impl Default for GameRules {
+    fn default() -> Self {
+        Self {
+            win_condition: WinCondition::Destination,
+            visibility: Visibility::Standard,
+            truncation: Truncation::Root,
+            timing: Timing::PerPlayer {
+                time_allowance: 600,
+                overtime_rule: OvertimeRule::FreeWildcard { period: 60 },
+            },
+            hand_size: 7,
+            tile_distribution: TileDistribution::Standard,
+            tile_bag_behaviour: TileBagBehaviour::Standard,
+            battle_rules: BattleRules { length_delta: 2 },
+            swapping: Swapping::Contiguous,
+        }
+    }
+}

--- a/truncate_server/src/game_state.rs
+++ b/truncate_server/src/game_state.rs
@@ -186,7 +186,7 @@ impl GameState {
             .enumerate()
             .find(|(_, p)| p.socket == Some(player))
         {
-            match self.game.play_move(Move::Place {
+            match self.game.play_turn(Move::Place {
                 player: player_index,
                 tile,
                 position,
@@ -304,7 +304,7 @@ impl GameState {
             .enumerate()
             .find(|(_, p)| p.socket == Some(player))
         {
-            match self.game.play_move(Move::Swap {
+            match self.game.play_turn(Move::Swap {
                 player: player_index,
                 positions: [from, to],
             }) {

--- a/truncate_server/src/game_state.rs
+++ b/truncate_server/src/game_state.rs
@@ -6,6 +6,7 @@ use truncate_core::{
     moves::Move,
     player::Hand,
     reporting::{BoardChange, BoardChangeAction, BoardChangeDetail, Change, HandChange},
+    rules::Visibility,
 };
 
 use crate::definitions::Definitions;
@@ -41,39 +42,20 @@ pub struct Player {
     pub socket: Option<SocketAddr>,
 }
 
-// TODO: Move this elsewhere, and make it a struct of rules
-pub enum GameMode {
-    Standard,
-    FogOfWar,
-}
-
 pub struct GameState {
     pub game_id: String,
     pub players: Vec<Player>,
     pub game: Game,
-    pub game_mode: GameMode,
 }
 
 impl GameState {
     pub fn new(game_id: String) -> Self {
         let game = Game::new(9, 9);
-        // let mut game = Game::new(13, 13);
-
-        // game.board.squares[7][6] = None;
-
-        // game.board.squares[7][8] = None;
-        // game.board.squares[7][10] = None;
-        // game.board.squares[7][12] = None;
-
-        // game.board.squares[7][4] = None;
-        // game.board.squares[7][2] = None;
-        // game.board.squares[7][0] = None;
 
         Self {
             game_id,
             players: vec![],
             game,
-            game_mode: GameMode::Standard,
         }
     }
 
@@ -98,9 +80,9 @@ impl GameState {
             .roots
             .get(player_index)
             .expect("Player should have a root square");
-        match self.game_mode {
-            GameMode::Standard => self.game.board.clone(),
-            GameMode::FogOfWar => self.game.board.fog_of_war(*root),
+        match self.game.rules.visibility {
+            Visibility::Standard => self.game.board.clone(),
+            Visibility::FogOfWar => self.game.board.fog_of_war(*root),
         }
     }
 
@@ -131,9 +113,9 @@ impl GameState {
                     {
                         return true;
                     }
-                    match self.game_mode {
-                        GameMode::Standard => true,
-                        GameMode::FogOfWar => match visible_board.get(*coordinate) {
+                    match self.game.rules.visibility {
+                        Visibility::Standard => true,
+                        Visibility::FogOfWar => match visible_board.get(*coordinate) {
                             Ok(Square::Occupied(_, _)) => true,
                             _ => false,
                         },


### PR DESCRIPTION
## Included
- Defined a game rules struct and baked in our current default game rules
- Relocated the main move() and resolve_attack() functions from the Board/Hand to being impl'd on the Game
- Fixed `moves.rs` tests

## Not Included
- We should relocate the moves.rs tests to a new module (maybe a `tests/*.rs` module setup) as there are many and they're testing the whole game now. 
- Moving the game_state logic from server into the game
- Using the game rules anywhere 