### PR TITLE
Iterative battle UI improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ word_freqs/package-lock.json
 word_freqs/en_word_freqs.txt
 truncate_client/img/package-lock.json
 _site
+# ungzipped word definition db
+defs.db

--- a/truncate_client/src/lil_bits/battle.rs
+++ b/truncate_client/src/lil_bits/battle.rs
@@ -9,26 +9,30 @@ use truncate_core::reporting::{BattleReport, BattleWord};
 
 use crate::{
     regions::active_game::GameCtx,
-    utils::{glyph_meaure::GlyphMeasure, Darken},
+    utils::{
+        glyph_meaure::GlyphMeasure, tex::paint_dialog_background, text::TextHelper, Darken, Lighten,
+    },
 };
 
 pub struct BattleUI<'a> {
     battle: &'a BattleReport,
+    latest: bool,
 }
 
 impl<'a> BattleUI<'a> {
-    pub fn new(battle: &'a BattleReport) -> Self {
-        Self { battle }
+    pub fn new(battle: &'a BattleReport, latest: bool) -> Self {
+        Self { battle, latest }
     }
 }
 
 fn get_galleys<'a>(
     battle_words: &'a Vec<BattleWord>,
+    transparent: bool,
     ctx: &GameCtx,
     ui: &mut egui::Ui,
 ) -> Vec<Arc<Galley>> {
     let dot = ui.painter().layout_no_wrap(
-        "•".into(),
+        "• ".into(),
         FontId::new(
             ctx.theme.letter_size * 0.75,
             egui::FontFamily::Name("Truncate-Heavy".into()),
@@ -46,10 +50,11 @@ fn get_galleys<'a>(
                         ctx.theme.letter_size * 0.75,
                         egui::FontFamily::Name("Truncate-Heavy".into()),
                     ),
-                    match w.valid {
-                        Some(true) => ctx.theme.addition.darken(),
-                        Some(false) => ctx.theme.defeated.darken(),
-                        None => ctx.theme.outlines.darken().darken(),
+                    match (transparent, w.valid) {
+                        (true, _) => Color32::TRANSPARENT,
+                        (false, Some(true)) => ctx.theme.addition.darken(),
+                        (false, Some(false)) => ctx.theme.defeated.darken(),
+                        (false, None) => ctx.theme.outlines.darken().darken(),
                     },
                 ),
                 dot.clone(),
@@ -120,10 +125,105 @@ fn paint_galleys<'a>(
     ui.allocate_rect(battle_rect, Sense::click())
 }
 
+#[derive(Clone, Copy, PartialEq)]
+struct BattleUIState {
+    hovered_last_frame: bool,
+    size_last_frame: Vec2,
+    /// If None, we defer to showing when it is the latest battle
+    show_details: Option<bool>,
+}
+
 impl<'a> BattleUI<'a> {
     pub fn render(self, ctx: &GameCtx, ui: &mut egui::Ui) {
+        let battle_id = Id::new("battle").with(self.battle.battle_number.unwrap_or_default());
+        let prev_battle_storage: Option<BattleUIState> =
+            ui.memory_mut(|m| m.data.get_temp(battle_id));
+
+        // Paint the background dialog based on the size of the battle last frame
+        if let Some(BattleUIState {
+            hovered_last_frame,
+            size_last_frame,
+            mut show_details,
+        }) = prev_battle_storage
+        {
+            let (dialog_rect, dialog_resp) = paint_dialog_background(
+                true,
+                false,
+                false,
+                size_last_frame,
+                if hovered_last_frame {
+                    Color32::WHITE
+                } else {
+                    ctx.theme.water.lighten()
+                },
+                &ctx.map_texture,
+                ui,
+            );
+            let offset = (dialog_rect.height() - size_last_frame.y) / 2.0;
+            let mut dialog_ui = ui.child_ui(dialog_rect, Layout::top_down(Align::Min));
+            dialog_ui.add_space(offset);
+
+            let battle_rect = self.render_innards(
+                ui.rect_contains_pointer(dialog_rect),
+                show_details.unwrap_or(self.latest),
+                prev_battle_storage,
+                ctx,
+                &mut dialog_ui,
+            );
+
+            let resp = ui.interact(
+                dialog_rect,
+                ui.auto_id_with("battle_interact"),
+                Sense::click(),
+            );
+
+            if resp.hovered() {
+                ui.output_mut(|o| o.cursor_icon = CursorIcon::PointingHand);
+            }
+            if resp.clicked() {
+                show_details = Some(!(show_details.unwrap_or(self.latest)));
+            }
+
+            // Save the sizing of our box for the next render pass to draw the background
+            let new_state = BattleUIState {
+                hovered_last_frame: resp.hovered(),
+                size_last_frame: battle_rect.size(),
+                show_details,
+            };
+            if prev_battle_storage != Some(new_state) {
+                ui.memory_mut(|m| m.data.insert_temp(battle_id, new_state));
+                ui.ctx().request_repaint();
+            }
+        } else {
+            // If we have no info on sizing, we can't paint the dialog background.
+            // Instead, we render everything transparent and trigger an immediate re-render.
+            let battle_rect = self.render_innards(false, false, prev_battle_storage, ctx, ui);
+            // Save the sizing of our box for the next render pass to draw the background
+            ui.memory_mut(|m| {
+                m.data.insert_temp(
+                    battle_id,
+                    BattleUIState {
+                        hovered_last_frame: false,
+                        show_details: None,
+                        size_last_frame: battle_rect.size(),
+                    },
+                )
+            });
+            ui.ctx().request_repaint();
+        }
+    }
+
+    fn render_innards(
+        &self,
+        hovered: bool,
+        active: bool,
+        prev_battle_storage: Option<BattleUIState>,
+        ctx: &GameCtx,
+        ui: &mut egui::Ui,
+    ) -> Rect {
         let mut theme = ctx.theme.rescale(0.5);
         theme.tile_margin = 0.0;
+        let render_transparent = prev_battle_storage.is_none();
 
         let mut battle_rect = Rect::NOTHING;
 
@@ -131,7 +231,7 @@ impl<'a> BattleUI<'a> {
             vec2(ui.available_size_before_wrap().x, 0.0),
             Layout::left_to_right(Align::Center).with_main_wrap(true),
             |ui| {
-                let words = get_galleys(&self.battle.attackers, ctx, ui);
+                let words = get_galleys(&self.battle.attackers, render_transparent, ctx, ui);
                 battle_rect = battle_rect.union(paint_galleys(words, ui, false).rect);
             },
         );
@@ -151,7 +251,11 @@ impl<'a> BattleUI<'a> {
                 ctx.theme.letter_size * 0.3,
                 egui::FontFamily::Name("Truncate-Heavy".into()),
             ),
-            ctx.theme.text,
+            if render_transparent {
+                Color32::TRANSPARENT
+            } else {
+                ctx.theme.text
+            },
         );
         battle_rect = battle_rect.union(paint_galleys(vec![galley], ui, false).rect);
         ui.add_space(5.0);
@@ -160,23 +264,61 @@ impl<'a> BattleUI<'a> {
             vec2(ui.available_size_before_wrap().x, 0.0),
             Layout::left_to_right(Align::Center).with_main_wrap(true),
             |ui| {
-                let words = get_galleys(&self.battle.defenders, ctx, ui);
+                let words = get_galleys(&self.battle.defenders, render_transparent, ctx, ui);
                 battle_rect = battle_rect.union(paint_galleys(words, ui, false).rect);
             },
         );
 
-        let battle_interact = ui.interact(battle_rect, ui.auto_id_with("battle"), Sense::click());
-        if battle_interact.hovered() {
-            ui.painter().rect_stroke(
-                battle_rect.expand2(vec2(0.0, 4.0)),
-                2.0,
-                Stroke::new(2.0, border_color),
-            );
-            ui.output_mut(|o| o.cursor_icon = CursorIcon::PointingHand);
+        if !active {
+            return battle_rect;
         }
 
-        battle_rect.set_right(battle_rect.left() + 6.0);
-        battle_rect = battle_rect.expand2(vec2(0.0, 4.0));
-        ui.painter().rect_filled(battle_rect, 0.0, border_color)
+        ui.add_space(8.0);
+
+        let definition_space = ui.horizontal(|ui| {
+            ui.add_space(12.0);
+            ui.with_layout(Layout::top_down(Align::Min), |ui| {
+                for word in self
+                    .battle
+                    .attackers
+                    .iter()
+                    .chain(self.battle.defenders.iter())
+                {
+                    ui.add_space(12.0);
+                    TextHelper::heavy(&word.original_word, ctx.theme.letter_size * 0.5, None, ui)
+                        .paint(ctx.theme.text, ui);
+
+                    match (word.valid, &word.meanings) {
+                        (Some(true), Some(meanings)) if !meanings.is_empty() => TextHelper::light(
+                            &format!("{}: {}", meanings[0].pos, meanings[0].defs[0]),
+                            24.0,
+                            Some(ui.available_width()),
+                            ui,
+                        )
+                        .paint(ctx.theme.text, ui),
+                        (Some(true), _) => TextHelper::light(
+                            "Definition unknown",
+                            24.0,
+                            Some(ui.available_width()),
+                            ui,
+                        )
+                        .paint(ctx.theme.text, ui),
+                        (Some(false), _) => {
+                            TextHelper::light("Invalid word", 24.0, Some(ui.available_width()), ui)
+                                .paint(ctx.theme.text, ui)
+                        }
+                        (None, _) => {
+                            TextHelper::light("Unchecked", 24.0, Some(ui.available_width()), ui)
+                                .paint(ctx.theme.text, ui)
+                        }
+                    };
+
+                    ui.add_space(12.0);
+                }
+            })
+        });
+        battle_rect = battle_rect.union(definition_space.response.rect);
+
+        battle_rect
     }
 }

--- a/truncate_client/src/regions/active_game.rs
+++ b/truncate_client/src/regions/active_game.rs
@@ -319,7 +319,9 @@ impl ActiveGame {
                             Change::Battle(battle) => Some(battle),
                             _ => None,
                         }) {
-                            if let Some(label) = if rendered_battles == 0 {
+                            let is_latest_battle = rendered_battles == 0;
+
+                            if let Some(label) = if is_latest_battle {
                                 Some("Latest Battle")
                             } else if rendered_battles == 1 {
                                 Some("Previous Battles")
@@ -335,9 +337,9 @@ impl ActiveGame {
                                 ui.painter().galley(r.min, label);
                             }
 
-                            BattleUI::new(battle).render(&mut self.ctx, ui);
+                            BattleUI::new(battle, is_latest_battle).render(&mut self.ctx, ui);
                             rendered_battles += 1;
-                            ui.add_space(15.0);
+                            ui.add_space(8.0);
                         }
                     }
                 });

--- a/truncate_client/src/regions/tutorial.rs
+++ b/truncate_client/src/regions/tutorial.rs
@@ -141,6 +141,7 @@ impl TutorialState {
             // TODO: Use some special infinite bag?
             bag: TileBag::new(&TileDistribution::Standard),
             judge: Judge::new(loaded_tutorial.dict.keys().cloned().collect()),
+            battle_count: 0,
             recent_changes: vec![],
             started_at: None,
             next_player: 0,

--- a/truncate_core/src/game.rs
+++ b/truncate_core/src/game.rs
@@ -30,6 +30,7 @@ pub struct Game {
     pub board: Board, // TODO: should these actually be public?
     pub bag: TileBag,
     pub judge: Judge,
+    pub battle_count: u32,
     pub recent_changes: Vec<Change>,
     pub started_at: Option<u64>,
     pub next_player: usize,
@@ -52,6 +53,7 @@ impl Game {
             board: Board::new(width, height),
             bag: TileBag::new(&rules.tile_distribution),
             judge: Judge::default(),
+            battle_count: 0,
             recent_changes: vec![],
             started_at: None,
             next_player: 0,
@@ -278,13 +280,16 @@ impl Game {
             .word_strings(&defenders)
             .expect("Words were just found and should be valid");
 
-        if let Some(battle) = self.judge.battle(
+        if let Some(mut battle) = self.judge.battle(
             attacking_words,
             defending_words,
             &self.rules.battle_rules,
             &self.rules.win_condition,
             external_dictionary,
         ) {
+            battle.battle_number = Some(self.battle_count);
+            self.battle_count += 1;
+
             match battle.outcome.clone() {
                 Outcome::DefenderWins => {
                     let mut all_defenders_are_towns = true;

--- a/truncate_core/src/judge.rs
+++ b/truncate_core/src/judge.rs
@@ -121,6 +121,7 @@ impl Judge {
         }
 
         let mut battle_report = BattleReport {
+            battle_number: None,
             attackers: attackers
                 .iter()
                 .map(|w| {
@@ -684,6 +685,7 @@ mod tests {
                 None
             ),
             Some(BattleReport {
+                battle_number: None,
                 attackers: vec![BattleWord {
                     original_word: "B*G".into(),
                     resolved_word: "BAG".into(),
@@ -708,6 +710,7 @@ mod tests {
                 None
             ),
             Some(BattleReport {
+                battle_number: None,
                 attackers: vec![BattleWord {
                     original_word: "R*G".into(),
                     resolved_word: "R*G".into(),
@@ -733,6 +736,7 @@ mod tests {
                 None
             ),
             Some(BattleReport {
+                battle_number: None,
                 attackers: vec![BattleWord {
                     original_word: "ARTS".into(),
                     resolved_word: "ARTS".into(),
@@ -757,6 +761,7 @@ mod tests {
                 None
             ),
             Some(BattleReport {
+                battle_number: None,
                 attackers: vec![BattleWord {
                     original_word: "BAG".into(),
                     resolved_word: "BAG".into(),

--- a/truncate_core/src/messages.rs
+++ b/truncate_core/src/messages.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     board::{Board, Coordinate},
     player::{Hand, Player},
-    reporting::Change,
+    reporting::{Change, WordMeaning},
 };
 
 pub type RoomCode = String;
@@ -25,6 +25,7 @@ pub enum PlayerMessage {
     Place(Coordinate, char),
     Swap(Coordinate, Coordinate),
     Rematch,
+    RequestDefinitions(Vec<String>),
 }
 
 impl fmt::Display for PlayerMessage {
@@ -47,6 +48,7 @@ impl fmt::Display for PlayerMessage {
             PlayerMessage::Place(coord, tile) => write!(f, "Place {} at {}", tile, coord),
             PlayerMessage::Swap(a, b) => write!(f, "Swap the tiles at {} and {}", a, b),
             PlayerMessage::Rematch => write!(f, "Rematch!"),
+            PlayerMessage::RequestDefinitions(words) => write!(f, "Get definition of {words:?}"),
         }
     }
 }
@@ -125,6 +127,7 @@ pub enum GameMessage {
     GameEnd(GameStateMessage, PlayerNumber),
     GameError(RoomCode, PlayerNumber, String),
     GenericError(String),
+    SupplyDefinitions(Vec<(String, Option<Vec<WordMeaning>>)>),
 }
 
 impl fmt::Display for GameMessage {
@@ -162,6 +165,9 @@ impl fmt::Display for GameMessage {
             }
             GameMessage::GameError(_, _, msg) => write!(f, "Error in game: {}", msg),
             GameMessage::GenericError(msg) => write!(f, "Generic error: {}", msg),
+            GameMessage::SupplyDefinitions(_) => {
+                write!(f, "Supplying definitions for words")
+            }
         }
     }
 }

--- a/truncate_core/src/reporting.rs
+++ b/truncate_core/src/reporting.rs
@@ -102,6 +102,7 @@ impl fmt::Display for BattleWord {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BattleReport {
+    pub battle_number: Option<u32>,
     pub attackers: Vec<BattleWord>,
     pub defenders: Vec<BattleWord>,
     pub outcome: Outcome,

--- a/truncate_server/src/definitions.rs
+++ b/truncate_server/src/definitions.rs
@@ -73,8 +73,15 @@ pub fn read_defs() -> WordDB {
         );
     }
 
+    let word_db_connection = Connection::open(defs_file).ok();
+    if word_db_connection.is_some() {
+        println!("Connected to the word definition database at {defs_file}");
+    } else {
+        println!("No word definitions available at {defs_file}. Set a TR_DEFS_FILE environment variable to point to a word db.");
+    }
+
     WordDB {
-        conn: Connection::open(defs_file).ok(),
+        conn: word_db_connection,
         room_codes: valid_words
             .keys()
             .filter(|k| k.len() < 6)

--- a/truncate_server/src/main.rs
+++ b/truncate_server/src/main.rs
@@ -501,6 +501,19 @@ async fn handle_player_msg(
                 }
             }
         }
+        RequestDefinitions(words) => {
+            let word_db = server_state.word_db.lock();
+            let definitions: Vec<_> = words
+                .iter()
+                .map(|word| (word.clone(), word_db.get_word(&word.to_lowercase()).clone()))
+                .collect();
+            // Don't hold the lock while sending messages
+            drop(word_db);
+
+            server_state
+                .send_to_player(&player_addr, GameMessage::SupplyDefinitions(definitions))
+                .unwrap();
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Not the final form here, but a shippable portion of work.

- Changed style of the battle info UI to match the new dialog design
- Battle summary can now be expanded to show the definitions of each word
- The latest battle starts expanded by default, and collapses when a new battle happens
- Closing or opening a battle summary overrides the default open/closed state

Additionally
- Single player mode now asks server for definitions after battles, and updates its stored battles if the server responds with definitions 🎉

---

<img width="296" alt="Screen Shot 2023-08-21 at 11 03 05 PM" src="https://github.com/TruncateGame/Truncate/assets/40188355/5240a4db-9452-4ff5-8adc-770a5d9d3aad">

---

_Code inside the Battle UI is kinda messy, but it already was. Didn't want to tackle refactoring._