### PR TITLE
Render towns a lil better in the battle UI

### DIFF
--- a/truncate_client/src/lil_bits/battle.rs
+++ b/truncate_client/src/lil_bits/battle.rs
@@ -44,19 +44,37 @@ fn get_galleys<'a>(
         .iter()
         .flat_map(|w| {
             [
-                ui.painter().layout_no_wrap(
-                    w.resolved_word.clone(),
-                    FontId::new(
-                        ctx.theme.letter_size * 0.75,
-                        egui::FontFamily::Name("Truncate-Heavy".into()),
-                    ),
-                    match (transparent, w.valid) {
-                        (true, _) => Color32::TRANSPARENT,
-                        (false, Some(true)) => ctx.theme.addition.darken(),
-                        (false, Some(false)) => ctx.theme.defeated.darken(),
-                        (false, None) => ctx.theme.outlines.darken().darken(),
-                    },
-                ),
+                if &w.original_word == "#" {
+                    ui.painter().layout_no_wrap(
+                        // TODO: It would be nice to phrase this as <player_name>'s town,
+                        // but we don't have player data in the battle UI yet so this is a good first step.
+                        "A TOWN".into(),
+                        FontId::new(
+                            ctx.theme.letter_size * 0.75,
+                            egui::FontFamily::Name("Truncate-Heavy".into()),
+                        ),
+                        match (transparent, w.valid) {
+                            (true, _) => Color32::TRANSPARENT,
+                            (false, Some(true)) => ctx.theme.addition.darken(),
+                            (false, Some(false)) => ctx.theme.defeated.darken(),
+                            (false, None) => ctx.theme.outlines.darken().darken(),
+                        },
+                    )
+                } else {
+                    ui.painter().layout_no_wrap(
+                        w.resolved_word.clone(),
+                        FontId::new(
+                            ctx.theme.letter_size * 0.75,
+                            egui::FontFamily::Name("Truncate-Heavy".into()),
+                        ),
+                        match (transparent, w.valid) {
+                            (true, _) => Color32::TRANSPARENT,
+                            (false, Some(true)) => ctx.theme.addition.darken(),
+                            (false, Some(false)) => ctx.theme.defeated.darken(),
+                            (false, None) => ctx.theme.outlines.darken().darken(),
+                        },
+                    )
+                },
                 dot.clone(),
             ]
         })
@@ -284,8 +302,11 @@ impl<'a> BattleUI<'a> {
                     .iter()
                     .chain(self.battle.defenders.iter())
                 {
+                    if &word.original_word == "#" {
+                        continue;
+                    }
                     ui.add_space(12.0);
-                    TextHelper::heavy(&word.original_word, ctx.theme.letter_size * 0.5, None, ui)
+                    TextHelper::heavy(&word.resolved_word, ctx.theme.letter_size * 0.5, None, ui)
                         .paint(ctx.theme.text, ui);
 
                     match (word.valid, &word.meanings) {


### PR DESCRIPTION
- Towns are rendered as `A TOWN` in a battle description
- Towns are not shown in the definitions list
- The resolved word is shown beside the definition instead of the original, which doesn't affect anything in MVP anyway