### PR TITLE
Prevent selecting empty board squares

### DIFF
--- a/truncate_client/src/lil_bits/board.rs
+++ b/truncate_client/src/lil_bits/board.rs
@@ -241,7 +241,9 @@ impl<'a> BoardUI<'a> {
                                                 }
                                                 next_selection = Some(None);
                                             } else {
-                                                next_selection = Some(Some(coord));
+                                                if matches!(square, Square::Occupied(_, _)) {
+                                                    next_selection = Some(Some(coord));
+                                                }
                                             }
                                         } else if let Some(tile) = ctx.released_tile {
                                             if tile.1 == coord {

--- a/truncate_client/src/lil_bits/board.rs
+++ b/truncate_client/src/lil_bits/board.rs
@@ -236,11 +236,13 @@ impl<'a> BoardUI<'a> {
                                             } else if is_selected {
                                                 next_selection = Some(None);
                                             } else if let Some(selected_coord) = ctx.selected_square_on_board {
+                                                // Only try to swap onto a tile, otherwise just deselect
                                                 if matches!(square, Square::Occupied(_, _)) {
                                                     msg = Some(PlayerMessage::Swap(coord, selected_coord));
                                                 }
                                                 next_selection = Some(None);
                                             } else {
+                                                // Don't select coordinates that are empty
                                                 if matches!(square, Square::Occupied(_, _)) {
                                                     next_selection = Some(Some(coord));
                                                 }


### PR DESCRIPTION
Previously we fixed selecting a tile and trying to swap it with an empty square. We did not fix the inverse, and that would still display an error. 