### PR TITLE
Adding a new error to warn user against tile placement next to opponent's artifact at the start of the game

### DIFF
--- a/truncate_core/src/error.rs
+++ b/truncate_core/src/error.rs
@@ -33,6 +33,8 @@ pub enum GamePlayError {
     OccupiedPlace,
     #[error("You can only place tiles touching your artifact or your existing tiles")]
     NonAdjacentPlace,
+    #[error("You are attempting to place a tile next to your opponent's artifact")]
+    OpponentStartPlace,
 
     #[error("Player {player:?} doesn't have a '{tile:?}' tile")]
     PlayerDoesNotHaveTile { player: usize, tile: char },

--- a/truncate_core/src/game.rs
+++ b/truncate_core/src/game.rs
@@ -566,7 +566,13 @@ impl Game {
                     return Err(GamePlayError::OccupiedPlace);
                 }
 
-                if !self.board.neighbouring_squares(position).iter().any(
+                let neighbors = self.board.neighbouring_squares(position);
+
+                if self.turn_count == 0 && neighbors.iter().any(|&(_, square)| matches!(square, Square::Artifact { player: p, .. } if p != player)) {
+                    return Err(GamePlayError::OpponentStartPlace);
+                }
+
+                if !neighbors.iter().any(
                     |&(_, square)| match square {
                         Square::Occupied { player: p, .. } => p == player,
                         Square::Artifact { player: p, .. } => p == player,

--- a/truncate_core/src/moves/mod.rs
+++ b/truncate_core/src/moves/mod.rs
@@ -143,6 +143,21 @@ mod tests {
             ..Game::new_legacy(3, 3, None, GameRules::generation(0))
         };
 
+        // Can't accidentally place beside opponent's artifact on first turn
+        assert_eq!(
+            game.make_move(
+                Move::Place {
+                    player: 0,
+                    tile: 'A',
+                    position: Coordinate { x: 2, y: 5 },
+                },
+                None,
+                None,
+                None,
+            ),
+            Err(GamePlayError::OpponentStartPlace)
+        );
+
         // Places beside artifact
         let changes = game.make_move(
             Move::Place {
@@ -999,6 +1014,7 @@ mod tests {
             players,
             player_turn_count: vec![0, 0],
             judge: short_dict(),
+            turn_count: 1, // any non zero value will do to avoid hitting OpponentStartPlace error
             ..Game::new_legacy(3, 1, None, GameRules::generation(0))
         };
         game.start();

--- a/truncate_core/src/npc/mod.rs
+++ b/truncate_core/src/npc/mod.rs
@@ -717,8 +717,11 @@ mod tests {
         initial_board: &'a str,
         depth: usize,
         dict: &WordDict,
+        turn_count: u32,
     ) -> (&'a str, String) {
         let mut game = test_game(initial_board, hand);
+        game.turn_count = turn_count;
+
         let (best_move, pruned_checks, total_checks) = best_test_move(&game, &dict, depth);
 
         enact_move(&mut game, best_move.clone(), &dict);
@@ -986,6 +989,7 @@ mod tests {
                 "###,
                 3,
                 &dict,
+                0,
             );
 
             insta::with_settings!({
@@ -1027,6 +1031,7 @@ mod tests {
                 "###,
                 3,
                 &dict,
+                0,
             );
 
             insta::with_settings!({
@@ -1068,6 +1073,7 @@ mod tests {
                 "###,
                 3,
                 &dict,
+                0,
             );
 
             insta::with_settings!({
@@ -1109,6 +1115,7 @@ mod tests {
                 "###,
                 3,
                 &dict,
+                0,
             );
 
             insta::with_settings!({
@@ -1150,6 +1157,7 @@ mod tests {
                 "###,
                 3,
                 &dict,
+                0,
             );
 
             insta::with_settings!({
@@ -1194,6 +1202,7 @@ mod tests {
                 "###,
                 3,
                 &dict,
+                0,
             );
 
             insta::with_settings!({
@@ -1241,6 +1250,7 @@ mod tests {
                 "###,
                 4,
                 &dict,
+                0,
             );
 
             insta::with_settings!({
@@ -1294,6 +1304,7 @@ mod tests {
                 "###,
                 2,
                 &dict,
+                3, // any non zero turn count value will do
             );
 
             insta::with_settings!({


### PR DESCRIPTION
I was playing today's daily puzzle and repeatedly tried to place my starting tile next to computer's artifact but didn't quite realize this. I figured it might be useful to have a specific error for this scenario. All tests pass locally and I confirmed desired behavior in the local client:
![Screenshot 2025-01-09 at 4 41 55 PM](https://github.com/user-attachments/assets/d8be1fba-88a6-4bd1-9c62-5eb961507040)
